### PR TITLE
chore: shuffle servers array on resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ const servers = resolver.getServers()
 ### setServers(servers)
 
 Sets the IP address and port of servers to be used when performing DNS resolution.
+Note that the servers order will be randomized on each request for load distribution.
 
 #### Parameters
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,25 @@ class Resolver {
   }
 
   /**
+   * Get a shuffled array of the IP addresses currently configured for DNS resolution.
+   * These addresses are formatted according to RFC 5952. It can include a custom port.
+   *
+   * @returns {Array<string>}
+   */
+  _getShuffledServers () {
+    const newServers = [].concat(this._servers)
+
+    for (let i = newServers.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * i)
+      const temp = newServers[i]
+      newServers[i] = newServers[j]
+      newServers[j] = temp
+    }
+
+    return newServers
+  }
+
+  /**
    * Sets the IP address and port of servers to be used when performing DNS resolution.
    *
    * @param {Array<string>} servers - array of RFC 5952 formatted addresses.
@@ -81,7 +100,7 @@ class Resolver {
       return cached
     }
 
-    for (const server of this._servers) {
+    for (const server of this._getShuffledServers()) {
       try {
         const response = await fetch(buildResource({
           serverResolver: server,
@@ -117,7 +136,7 @@ class Resolver {
       return cached
     }
 
-    for (const server of this._servers) {
+    for (const server of this._getShuffledServers()) {
       try {
         const response = await fetch(buildResource({
           serverResolver: server,
@@ -153,7 +172,7 @@ class Resolver {
       return cached
     }
 
-    for (const server of this._servers) {
+    for (const server of this._getShuffledServers()) {
       try {
         const response = await fetch(buildResource({
           serverResolver: server,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,6 +37,23 @@ describe('dns-over-http-resolver', () => {
     expect(servers2[0]).to.eql(newServer)
   })
 
+  it('shuffles the available servers on resolve', async () => {
+    const hostname = 'google.com'
+    const recordType = 'A'
+
+    const stub = sinon.stub(...getFetchPair())
+    stub.returns(Promise.resolve({
+      json: () => ({
+        Question: [{ name: 'google.com', type: 1 }],
+        Answer: [{ name: 'google.com', type: 1, TTL: 285, data: '216.58.212.142' }]
+      })
+    }))
+
+    sinon.spy(resolver, '_getShuffledServers')
+    await resolver.resolve(hostname, recordType)
+    expect(resolver._getShuffledServers.callCount).to.eql(1)
+  })
+
   it('resolves a dns record of type A', async () => {
     const hostname = 'google.com'
     const recordType = 'A'


### PR DESCRIPTION
This PR adds a shuffle for the servers array before resolving.

While this does not need a perfect random generator, the used solution was based on this [blogpost](https://medium.com/@nitinpatel_20236/how-to-shuffle-correctly-shuffle-an-array-in-javascript-15ea3f84bfb).

Closes #3 

cc @jacobheun