### PR TITLE
feat: allow aborting DNS requests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,11 +27,12 @@ interface Answer {
 /**
  * Use fetch to find the record
  */
-export async function request (resource: string) {
+export async function request (resource: string, signal: AbortSignal) {
   const req = await nativeFetch(resource, {
     headers: new Headers({
       accept: 'application/dns-json'
-    })
+    }),
+    signal
   })
   const res = await req.json()
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -260,4 +260,29 @@ describe('dns-over-http-resolver', () => {
     expect(response).to.exist()
     expect(response).to.deep.equal(['216.58.212.142'])
   })
+
+  it('cancels an in-flight DNS request', async () => {
+    const hostname = 'example.com'
+
+    const request = async (host: string, signal: AbortSignal) => {
+      return await new Promise<DNSJSON>((resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new Error('aborted'))
+        })
+      })
+    }
+
+    resolver = new DnsOverHttpResolver({ request })
+    resolver.setServers(['https://dns.google/resolve'])
+
+    const resolvePromise = resolver.resolve(hostname)
+
+    expect(resolver).to.have.property('_abortControllers').that.is.not.empty('Did not store abortcontroller')
+
+    resolver.cancel()
+
+    await expect(resolvePromise).to.eventually.be.rejected()
+
+    expect(resolver).to.have.property('_abortControllers').that.is.empty('Did not remove abortcontroller after aborting')
+  })
 })


### PR DESCRIPTION
Adds a `.cancel` method to the resolver which cancels all in-flight DNS requests - see [resolver.cancel](https://nodejs.org/api/dns.html#resolvercancel) in Node.js