### PR TITLE
fix: add `undici` to satisfy peer dep requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
   "dependencies": {
     "debug": "^4.3.1",
     "native-fetch": "^4.0.2",
-    "receptacle": "^1.3.2"
+    "receptacle": "^1.3.2",
+    "undici": "^5.12.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",


### PR DESCRIPTION
The module `native-fetch` requires `undici` to be installed as its peer dependency.

Before this change, `pnpm add` was reporting a missing peer dependency.

    dependencies:
    + dns-over-http-resolver 2.1.0

     WARN  Issues with peer dependencies found
    .
    └─┬ dns-over-http-resolver 2.1.0
      └─┬ native-fetch 4.0.2
        └── ✕ missing peer undici@"*"
    Peer dependencies that should be installed:
      undici@"*"

With this change in place, there are no warnings reported.

    dependencies:
    + dns-over-http-resolver 2.1.1

    Progress: resolved 9, reused 9, downloaded 0, added 9, done

_To be honest, I think it would be better to add `undici` as a dependency to `native-fetch`, as that would fix the problem for all consumers of `native-fetch`. However, in https://github.com/libp2p/js-libp2p/issues/1487, @achingbrain suggested to fix the problem in this repo, so here we are._

Fixes #44 