### PR TITLE
fix!: use native fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "native-fetch": "^4.0.2",
     "receptacle": "^1.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -135,10 +135,9 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "debug": "^4.3.1",
+    "debug": "^4.3.4",
     "native-fetch": "^4.0.2",
-    "receptacle": "^1.3.2",
-    "undici": "^5.12.0"
+    "receptacle": "^1.3.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import { fetch as nativeFetch, Headers } from 'native-fetch'
-
 /**
  * Build fetch resource for request
  */
@@ -28,7 +26,7 @@ interface Answer {
  * Use fetch to find the record
  */
 export async function request (resource: string, signal: AbortSignal): Promise<DNSJSON> {
-  const req = await nativeFetch(resource, {
+  const req = await fetch(resource, {
     headers: new Headers({
       accept: 'application/dns-json'
     }),


### PR DESCRIPTION
Node 18 now has [global fetch](https://nodejs.org/en/blog/announcements/v18-release-announce) and given that electron now ships with [node 18 by default](https://github.com/electron/electron/pull/36924) , I don't think we need this peer-dependency anymore.

Related: https://github.com/vasco-santos/dns-over-http-resolver/pull/78